### PR TITLE
Recommend `--bind-interfaces` when using `dnsmasq`

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,14 @@ Installing dnsmasq is a good way to test it:
 
 ```bash
 $ sudo yum install dnsmasq
-$ dnsmasq -p 5353 --no-daemon --address=/test.dev/127.0.0.1
+$ dnsmasq --bind-interfaces -p 5353 --no-daemon --address=/test.dev/127.0.0.1
 ```
 
 Now you can try this:
 
 ```bash
 # ping sufix
-$ ping test.dev 
+$ ping test.dev
 # or any "subdomain"
 $ ping any.test.dev
 ```


### PR DESCRIPTION
Because of LXC I have another dnsmasq instance running on my machine and I was seeing some weird behavior when creating / destroying docker / lxc containers. I'm not sure if it is related but it made my setup a whole lot more stable

```
       -z, --bind-interfaces
              On systems which support it, dnsmasq binds the wildcard address, even when it is listening on only some interfaces. It then discards
              requests that it shouldn't reply to. This has the advantage of working even when interfaces come and go  and  change  address.  This
              option forces dnsmasq to really bind only the interfaces it is listening on. About the only time when this is useful is when running
              another nameserver (or another instance of dnsmasq) on the same machine. Setting this option also enables multiple instances of dns‐
              masq which provide DHCP service to run in the same machine.
```
